### PR TITLE
Update iterator translate

### DIFF
--- a/docs/array.md
+++ b/docs/array.md
@@ -86,7 +86,7 @@ Array.of(3).length // 1
 Array() // []
 Array(3) // [undefined, undefined, undefined]
 Array(3,11,8) // [3, 11, 8]
-		
+
 ```
 
 上面代码说明，只有当参数个数不少于2个，Array()才会返回由参数组成的新数组。
@@ -99,7 +99,7 @@ Array(3,11,8) // [3, 11, 8]
 
 [1, 5, 10, 15].find(function(value, index, arr) {
 	return value > 9;
-}) // 10 
+}) // 10
 
 ```
 
@@ -111,7 +111,7 @@ Array(3,11,8) // [3, 11, 8]
 
 [1, 5, 10, 15].findIndex(function(value, index, arr) {
 	return value > 9;
-}) // 2 
+}) // 2
 
 ```
 
@@ -121,7 +121,7 @@ Array(3,11,8) // [3, 11, 8]
 
 ```javascript
 
-[NaN].indexOf(NaN) 
+[NaN].indexOf(NaN)
 // -1
 
 [NaN].findIndex(y => Object.is(NaN, y))
@@ -156,7 +156,7 @@ fill()还可以接受第二个和第三个参数，用于指定填充的起始�
 
 ## 数组实例的entries()，keys()和values()
 
-ES6提供三个新的方法——entries()，keys()和values()——用于遍历数组。它们都返回一个遍历器，可以用for...of循环进行遍历，唯一的区别是keys()是对键名的遍历、values()是对键值的遍历，entries()是对键值对的遍历。
+ES6提供三个新的方法——entries()，keys()和values()——用于遍历数组。它们都返回一个迭代器，可以用for...of循环进行遍历，唯一的区别是keys()是对键名的遍历、values()是对键值的遍历，entries()是对键值对的遍历。
 
 ```javascript
 

--- a/docs/generator.md
+++ b/docs/generator.md
@@ -4,9 +4,9 @@
 
 ### 简介
 
-所谓Generator，有多种理解角度。首先，可以把它理解成一个函数的内部状态的遍历器，每调用一次，函数的内部状态发生一次改变（可以理解成发生某些事件）。ES6引入Generator函数，作用就是可以完全控制函数的内部状态的变化，依次遍历这些状态。
+所谓Generator，有多种理解角度。首先，可以把它理解成一个函数的内部状态的迭代器，每调用一次，函数的内部状态发生一次改变（可以理解成发生某些事件）。ES6引入Generator函数，作用就是可以完全控制函数的内部状态的变化，依次遍历这些状态。
 
-在形式上，Generator是一个普通函数，但是有两个特征。一是，function命令与函数名之间有一个星号；二是，函数体内部使用yield语句，定义遍历器的每个成员，即不同的内部状态（yield语句在英语里的意思就是“产出”）。
+在形式上，Generator是一个普通函数，但是有两个特征。一是，function命令与函数名之间有一个星号；二是，函数体内部使用yield语句，定义迭代器的每个成员，即不同的内部状态（yield语句在英语里的意思就是“产出”）。
 
 ```javascript
 
@@ -20,13 +20,13 @@ var hw = helloWorldGenerator();
 
 ```
 
-上面代码定义了一个Generator函数helloWorldGenerator，它的遍历器有两个成员“hello”和“world”。调用这个函数，就会得到遍历器。
+上面代码定义了一个Generator函数helloWorldGenerator，它的迭代器有两个成员“hello”和“world”。调用这个函数，就会得到迭代器。
 
-当调用Generator函数的时候，该函数并不执行，而是返回一个遍历器（可以理解成暂停执行）。以后，每次调用这个遍历器的next方法，就从函数体的头部或者上一次停下来的地方开始执行（可以理解成恢复执行），直到遇到下一个yield语句为止。也就是说，next方法就是在遍历yield语句定义的内部状态。
+当调用Generator函数的时候，该函数并不执行，而是返回一个迭代器（可以理解成暂停执行）。以后，每次调用这个迭代器的next方法，就从函数体的头部或者上一次停下来的地方开始执行（可以理解成恢复执行），直到遇到下一个yield语句为止。也就是说，next方法就是在遍历yield语句定义的内部状态。
 
 ```javascript
 
-hw.next() 
+hw.next()
 // { value: 'hello', done: false }
 
 hw.next()
@@ -52,7 +52,7 @@ hw.next()
 
 总结一下，Generator函数使用iterator接口，每次调用next方法的返回值，就是一个标准的iterator返回值：有着value和done两个属性的对象。其中，value是yield语句后面那个表达式的值，done是一个布尔值，表示是否遍历结束。
 
-上一章说过，任意一个对象的Symbol.iterator属性，等于该对象的遍历器函数，即调用该函数会返回该对象的一个遍历器。由于Generator函数调用后返回自身的遍历器，所以Generator函数就是自身的遍历器函数，即它的Symbol.iterator属性指向自身。
+上一章说过，任意一个对象的Symbol.iterator属性，等于该对象的迭代器函数，即调用该函数会返回该对象的一个迭代器。由于Generator函数调用后返回自身的迭代器，所以Generator函数就是自身的迭代器函数，即它的Symbol.iterator属性指向自身。
 
 ```javascript
 
@@ -67,7 +67,7 @@ gen[Symbol.iterator]() === gen
 
 上面代码中，gen是一个Generator函数，它的Symbol.iterator属性就指向它自己。
 
-由于Generator函数返回的遍历器，只有调用next方法才会遍历下一个成员，所以其实提供了一种可以暂停执行的函数。yield语句就是暂停标志，next方法遇到yield，就会暂停执行后面的操作，并将紧跟在yield后面的那个表达式的值，作为返回对象的value属性的值。当下一次调用next方法时，再继续往下执行，直到遇到下一个yield语句。如果没有再遇到新的yield语句，就一直运行到函数结束，将return语句后面的表达式的值，作为value属性的值，如果该函数没有return语句，则value属性的值为undefined。另一方面，由于yield后面的表达式，直到调用next方法时才会执行，因此等于为JavaScript提供了手动的“惰性求值”（Lazy Evaluation）的语法功能。
+由于Generator函数返回的迭代器，只有调用next方法才会遍历下一个成员，所以其实提供了一种可以暂停执行的函数。yield语句就是暂停标志，next方法遇到yield，就会暂停执行后面的操作，并将紧跟在yield后面的那个表达式的值，作为返回对象的value属性的值。当下一次调用next方法时，再继续往下执行，直到遇到下一个yield语句。如果没有再遇到新的yield语句，就一直运行到函数结束，将return语句后面的表达式的值，作为value属性的值，如果该函数没有return语句，则value属性的值为undefined。另一方面，由于yield后面的表达式，直到调用next方法时才会执行，因此等于为JavaScript提供了手动的“惰性求值”（Lazy Evaluation）的语法功能。
 
 yield语句与return语句有点像，都能返回紧跟在语句后面的那个表达式的值。区别在于每次遇到yield，函数暂停执行，下一次再从该位置继续向后执行，而return语句不具备位置记忆的功能。一个函数里面，只能执行一次（或者说一个）return语句，但是可以执行多次（或者说多个）yield语句。正常函数只能返回一个值，因为只能执行一次return；Generator函数可以返回一系列的值，因为可以有任意多个yield。从另一个角度看，也可以说Generator生成了一系列的值，这也就是它的名称的来历（在英语中，generator这个词是“生成器”的意思）。
 
@@ -82,7 +82,7 @@ function* f() {
 var generator = f();
 
 setTimeout(function () {
-  generator.next() 
+  generator.next()
 }, 2000);
 
 ```
@@ -111,7 +111,7 @@ var arr = [1, [[2, 3], 4], [5, 6]];
 var flat = function* (a){
   a.forEach(function(item){
     if (typeof item !== 'number'){
-      yield* flat(item);  
+      yield* flat(item);
     } else {
       yield item;
     }
@@ -135,7 +135,7 @@ var flat = function* (a){
   for(var i =0;i<length;i++){
     var item = a[i];
     if (typeof item !== 'number'){
-      yield* flat(item);  
+      yield* flat(item);
     } else {
       yield item;
     }
@@ -277,7 +277,7 @@ try {
 
 ```
 
-上面代码中，遍历器i连续抛出两个错误。第一个错误被Generator函数体内的catch捕获，然后Generator函数执行完成，于是第二个错误被函数体外的catch捕获。
+上面代码中，迭代器i连续抛出两个错误。第一个错误被Generator函数体内的catch捕获，然后Generator函数执行完成，于是第二个错误被函数体外的catch捕获。
 
 这种函数体内捕获错误的机制，大大方便了对错误的处理。如果使用回调函数的写法，想要捕获多个错误，就不得不为每个函数写一个错误处理语句。
 
@@ -287,17 +287,17 @@ foo('a', function (a) {
     if (a.error) {
         throw new Error(a.error);
     }
- 
+
     foo('b', function (b) {
         if (b.error) {
             throw new Error(b.error);
         }
- 
+
         foo('c', function (c) {
             if (c.error) {
                 throw new Error(c.error);
             }
- 
+
             console.log(a, b, c);
         });
     });
@@ -347,7 +347,7 @@ try {
 
 function *foo() {
     var x = yield 3;
-    var y = x.toUpperCase(); 
+    var y = x.toUpperCase();
     yield y;
 }
 
@@ -356,7 +356,7 @@ var it = foo();
 it.next(); // { value:3, done:false }
 
 try {
-  it.next( 42 ); 
+  it.next( 42 );
 }
 catch (err) {
   console.log( err );
@@ -408,14 +408,14 @@ log(g());
 // fixing generator { value: 1, done: false }
 // fixing generator { value: 1, done: false }
 // caller done
- 
+
 ```
 
 上面代码在Generator函数g抛出错误以后，再调用next方法，就不再执行下去了，一直停留在上一次的状态。
 
 ### yield*语句
 
-如果yield命令后面跟的是一个遍历器，需要在yield命令后面加上星号，表明它返回的是一个遍历器。这被称为yield*语句。
+如果yield命令后面跟的是一个迭代器，需要在yield命令后面加上星号，表明它返回的是一个迭代器。这被称为yield*语句。
 
 ```javascript
 
@@ -440,9 +440,9 @@ for(let value of delegatingIterator) {
 
 ```
 
-上面代码中，delegatingIterator是代理者，delegatedIterator是被代理者。由于`yield* delegatedIterator`语句得到的值，是一个遍历器，所以要用星号表示。运行结果就是使用一个遍历器，遍历了多个Genertor函数，有递归的效果。
+上面代码中，delegatingIterator是代理者，delegatedIterator是被代理者。由于`yield* delegatedIterator`语句得到的值，是一个迭代器，所以要用星号表示。运行结果就是使用一个迭代器，遍历了多个Genertor函数，有递归的效果。
 
-如果`yield*`后面跟着一个数组，就表示该数组会返回一个遍历器，因此就会遍历数组成员。
+如果`yield*`后面跟着一个数组，就表示该数组会返回一个迭代器，因此就会遍历数组成员。
 
 ```javascript
 
@@ -454,7 +454,7 @@ gen().next() // { value:"a", done:false }
 
 ```
 
-上面代码中，yield命令后面如果不加星号，返回的是整个数组，加了星号就表示返回的是数组的遍历器。
+上面代码中，yield命令后面如果不加星号，返回的是整个数组，加了星号就表示返回的是数组的迭代器。
 
 如果被代理的Generator函数有return语句，那么就可以向代理它的Generator函数返回数据。
 
@@ -478,7 +478,7 @@ var it = bar();
 it.next(); //
 it.next(); //
 it.next(); //
-it.next(); // "v: foo" 
+it.next(); // "v: foo"
 it.next(); //
 
 ```
@@ -525,7 +525,7 @@ function Tree(left, label, right) {
 }
 
 // 下面是中序（inorder）遍历函数。
-// 由于返回的是一个遍历器，所以要用generator函数。
+// 由于返回的是一个迭代器，所以要用generator函数。
 // 函数体内采用递归算法，所以左树和右树要用yield*遍历
 function* inorder(t) {
   if (t) {
@@ -546,7 +546,7 @@ let tree = make([[['a'], 'b', ['c']], 'd', [['e'], 'f', ['g']]]);
 // 遍历二叉树
 var result = [];
 for (let node of inorder(tree)) {
-  result.push(node); 
+  result.push(node);
 }
 
 result
@@ -636,21 +636,21 @@ Generator函数的暂停执行的效果，意味着可以把异步操作写在yi
 
 ```javascript
 
-function* loadUI() { 
-	showLoadingScreen(); 
-	yield loadUIDataAsynchronously(); 
-	hideLoadingScreen(); 
-} 
+function* loadUI() {
+	showLoadingScreen();
+	yield loadUIDataAsynchronously();
+	hideLoadingScreen();
+}
 var loader = loadUI();
 // 加载UI
-loader.next() 
+loader.next()
 
 // 卸载UI
 loader.next()
 
 ```
 
-上面代码表示，第一次调用loadUI函数时，该函数不会执行，仅返回一个遍历器。下一次对该遍历器调用next方法，则会显示Loading界面，并且异步加载数据。等到数据加载完成，再一次使用next方法，则会隐藏Loading界面。可以看到，这种写法的好处是所有Loading界面的逻辑，都被封装在一个函数，按部就班非常清晰。
+上面代码表示，第一次调用loadUI函数时，该函数不会执行，仅返回一个迭代器。下一次对该迭代器调用next方法，则会显示Loading界面，并且异步加载数据。等到数据加载完成，再一次使用next方法，则会隐藏Loading界面。可以看到，这种写法的好处是所有Loading界面的逻辑，都被封装在一个函数，按部就班非常清晰。
 
 Ajax是典型的异步操作，通过Generator函数部署Ajax操作，可以用同步的方式表达。
 
@@ -734,7 +734,7 @@ Q.fcall(step1)
 ```javascript
 
 function* longRunningTask() {
-  try {	
+  try {
     var value1 = yield step1();
     var value2 = yield step2(value1);
     var value3 = yield step3(value2);
@@ -771,7 +771,7 @@ function scheduler(task) {
 ```javascript
 
 var Q = require('q');
- 
+
 function delay(milliseconds) {
   var deferred = Q.defer();
   setTimeout(deferred.resolve, milliseconds);
@@ -835,7 +835,7 @@ for (let [key, value] of iterEntries(myObj)) {
 
 function* makeSimpleGenerator(array){
   var nextIndex = 0;
-    
+
   while(nextIndex < array.length){
     yield array[nextIndex++];
   }
@@ -888,4 +888,3 @@ function doStuff() {
 ```
 
 上面的函数，可以用一模一样的for...of循环处理！两相一比较，就不难看出Generator使得数据或者操作，具备了类似数组的接口。
-

--- a/docs/iterator.md
+++ b/docs/iterator.md
@@ -1,14 +1,14 @@
 # Iterator和for...of循环
 
-## Iterator（遍历器）
+## Iterator（迭代器）
 
 ### 概念
 
 JavaScript原有的数据结构，主要是数组（Array）和对象（Object），ES6又添加了Map和Set，用户还可以组合使用它们，定义自己的数据结构。这就需要一种统一的接口机制，来处理所有不同的数据结构。
 
-遍历器（Iterator）就是这样一种机制。它属于一种接口规格，任何数据结构只要部署这个接口，就可以完成遍历操作，即依次处理该结构的所有成员。它的作用有两个，一是为各种数据结构，提供一个统一的、简便的接口，二是使得数据结构的成员能够按某种次序排列。在ES6中，遍历操作特指for...of循环，即Iterator接口主要供for...of消费。
+迭代器（Iterator）就是这样一种机制。它属于一种接口规格，任何数据结构只要部署这个接口，就可以完成遍历操作，即依次处理该结构的所有成员。它的作用有两个，一是为各种数据结构，提供一个统一的、简便的接口，二是使得数据结构的成员能够按某种次序排列。在ES6中，遍历操作特指for...of循环，即Iterator接口主要供for...of消费。
 
-遍历器的遍历过程是这样的：它提供了一个指针，默认指向当前数据结构的起始位置。第一次调用遍历器的next方法，可以将指针指向到第一个成员，第二次调用就指向第二个成员，直至指向数据结构的结束位置。每一次调用，都会返回当前成员的信息，具体来说，就是返回一个包含value和done两个属性的对象。其中，value属性是当前成员的值，done属性是一个布尔值，表示遍历是否结束。
+迭代器的遍历过程是这样的：它提供了一个指针，默认指向当前数据结构的起始位置。第一次调用迭代器的next方法，可以将指针指向到第一个成员，第二次调用就指向第二个成员，直至指向数据结构的结束位置。每一次调用，都会返回当前成员的信息，具体来说，就是返回一个包含value和done两个属性的对象。其中，value属性是当前成员的值，done属性是一个布尔值，表示遍历是否结束。
 
 下面是一个模拟next方法返回值的例子。
 
@@ -33,15 +33,15 @@ it.next() // { value: undefined, done: true }
 
 ```
 
-上面代码定义了一个makeIterator函数，它的参数是一个数组。调用该函数，就会返回一个对象。这个对象具有一个next方法，每次调用next方法，它的内部指针就会指向数组的下一个成员，并返回一个该成员信息的对象。请特别注意，next方法的返回值的构造：一个具有value和done两个属性的对象。通过这个返回值，我们就可以知道当前成员的值是什么，以及遍历是否结束。在这个例子中，makeIterator函数用来生成遍历器，它返回的那个具有next方法的对象就是遍历器，调用遍历器的next方法，就可以遍历事先给定的数组。
+上面代码定义了一个makeIterator函数，它的参数是一个数组。调用该函数，就会返回一个对象。这个对象具有一个next方法，每次调用next方法，它的内部指针就会指向数组的下一个成员，并返回一个该成员信息的对象。请特别注意，next方法的返回值的构造：一个具有value和done两个属性的对象。通过这个返回值，我们就可以知道当前成员的值是什么，以及遍历是否结束。在这个例子中，makeIterator函数用来生成迭代器，它返回的那个具有next方法的对象就是迭代器，调用迭代器的next方法，就可以遍历事先给定的数组。
 
-因为遍历器的作用，只是把接口规格加到数据结构之上。所以，遍历器与它所遍历的那个数据结构，实际上是分开的，完全可以写出没有对应数据结构的遍历器，或者说用遍历器模拟出数据结构。下面是一个无限运行的遍历器例子。
+因为迭代器的作用，只是把接口规格加到数据结构之上。所以，迭代器与它所遍历的那个数据结构，实际上是分开的，完全可以写出没有对应数据结构的迭代器，或者说用迭代器模拟出数据结构。下面是一个无限运行的迭代器例子。
 
 ```javascript
 
 function idMaker(){
   var index = 0;
-    
+
   return {
     next: function(){
       return {value: index++, done: false};
@@ -58,11 +58,11 @@ it.next().value // '2'
 
 ```
 
-上面的例子中，idMaker函数返回的对象就是遍历器，但是并没有对应的数据结构，或者说遍历器自己描述了一个数据结构出来。
+上面的例子中，idMaker函数返回的对象就是迭代器，但是并没有对应的数据结构，或者说迭代器自己描述了一个数据结构出来。
 
-总之，所谓Iterator接口，就是指调用这个接口，会返回一个遍历器对象。该对象具备next方法，每次调用该方法，会返回一个具有value和done两个属性的新对象，指向部署了Iterator接口的数据结构的一个成员。
+总之，所谓Iterator接口，就是指调用这个接口，会返回一个迭代器对象。该对象具备next方法，每次调用该方法，会返回一个具有value和done两个属性的新对象，指向部署了Iterator接口的数据结构的一个成员。
 
-如果使用TypeScript的写法，遍历器接口、遍历器和遍历器返回值的规格可以描述如下。
+如果使用TypeScript的写法，迭代器接口、迭代器和迭代器返回值的规格可以描述如下。
 
 ```javascript
 
@@ -85,7 +85,7 @@ interface IterationResult {
 
 Iterator接口的开发目的，就是为所有数据结构，提供了一种统一的访问机制，即for...of循环（见后文的介绍）。当使用for...of循环，遍历某种数据结构时，该循环会自动去寻找Iterator接口。
 
-ES6规定，默认的Iterator接口部署在数据结构的Symbol.iterator属性。也就是说，调用Symbol.iterator方法，就会得到当前数据结构的默认遍历器。Symbol.iterator是一个表达式，返回Symbol对象的iterator属性，这是一个预定义好的、类型为Symbol的特殊值，所以要放在方括号内（请参考Symbol一节）。
+ES6规定，默认的Iterator接口部署在数据结构的Symbol.iterator属性。也就是说，调用Symbol.iterator方法，就会得到当前数据结构的默认迭代器。Symbol.iterator是一个表达式，返回Symbol对象的iterator属性，这是一个预定义好的、类型为Symbol的特殊值，所以要放在方括号内（请参考Symbol一节）。
 
 在ES6中，有三类数据结构原生具备Iterator接口：数组、某些类似数组的对象、Set和Map结构。
 
@@ -101,19 +101,19 @@ iter.next() // { value: undefined, done: true }
 
 ```
 
-上面代码中，变量arr是一个数组，原生就具有遍历器接口，部署在arr的Symbol.iterator属性上面。所以，调用这个属性，就得到遍历器。
+上面代码中，变量arr是一个数组，原生就具有迭代器接口，部署在arr的Symbol.iterator属性上面。所以，调用这个属性，就得到迭代器。
 
-上面提到，原生就部署iterator接口的数据结构有三类，对于这三类数据结构，不用自己写遍历器，for...of循环会自动遍历它们。除此之外，其他数据结构（主要是对象）的Iterator接口，都需要自己在Symbol.iterator属性上面部署，这样才会被for...of循环遍历。
+上面提到，原生就部署iterator接口的数据结构有三类，对于这三类数据结构，不用自己写迭代器，for...of循环会自动遍历它们。除此之外，其他数据结构（主要是对象）的Iterator接口，都需要自己在Symbol.iterator属性上面部署，这样才会被for...of循环遍历。
 
-对象（Object）之所以没有默认部署Iterator接口，是因为对象的哪个属性先遍历，哪个属性后遍历是不确定的，需要开发者手动指定。本质上，遍历器是一种线性处理，对于任何非线性的数据结构，部署遍历器接口，就等于部署一种线性转换。不过，严格地说，对象部署遍历器接口并不是很必要，因为这时对象实际上被当作Map结构使用，ES5没有Map结构，而ES6原生提供了。
+对象（Object）之所以没有默认部署Iterator接口，是因为对象的哪个属性先遍历，哪个属性后遍历是不确定的，需要开发者手动指定。本质上，迭代器是一种线性处理，对于任何非线性的数据结构，部署迭代器接口，就等于部署一种线性转换。不过，严格地说，对象部署迭代器接口并不是很必要，因为这时对象实际上被当作Map结构使用，ES5没有Map结构，而ES6原生提供了。
 
-一个对象如果要有可被for...of循环调用的Iterator接口，就必须在Symbol.iterator的属性上部署遍历器方法（原型链上的对象具有该方法也可）。
+一个对象如果要有可被for...of循环调用的Iterator接口，就必须在Symbol.iterator的属性上部署迭代器方法（原型链上的对象具有该方法也可）。
 
 ```javascript
 
 class MySpecialTree {
   // ...
-  [Symbol.iterator]() { 
+  [Symbol.iterator]() {
     // ...
     return theIterator;
   }
@@ -121,7 +121,7 @@ class MySpecialTree {
 
 ```
 
-上面代码是一个类部署Iterator接口的写法。Symbol.iterator属性对应一个函数，执行后返回当前对象的遍历器。下面是一个例子。
+上面代码是一个类部署Iterator接口的写法。Symbol.iterator属性对应一个函数，执行后返回当前对象的迭代器。下面是一个例子。
 
 ```javascript
 
@@ -131,11 +131,11 @@ function Obj(value){
 }
 
 Obj.prototype[Symbol.iterator] = function(){
-  
+
   var iterator = {
     next: next
   };
-  
+
   var current = this;
 
   function next(){
@@ -171,7 +171,7 @@ for (var i of one){
 
 ```
 
-上面代码首先在构造函数的原型链上部署Symbol.iterator方法，调用该方法会返回遍历器对象iterator，调用该对象的next方法，在返回一个值的同时，自动将内部指针移到下一个实例。
+上面代码首先在构造函数的原型链上部署Symbol.iterator方法，调用该方法会返回迭代器对象iterator，调用该对象的next方法，在返回一个值的同时，自动将内部指针移到下一个实例。
 
 下面是另一个为对象添加Iterator接口的例子。
 
@@ -207,7 +207,7 @@ NodeList.prototype[Symbol.iterator] = Array.prototype[Symbol.iterator];
 
 ```
 
-如果Symbol.iterator方法返回的不是遍历器，解释引擎将会报错。
+如果Symbol.iterator方法返回的不是迭代器，解释引擎将会报错。
 
 ```javascript
 
@@ -219,7 +219,7 @@ obj[Symbol.iterator] = () => 1;
 
 ```
 
-上面代码中，变量obj的Symbol.iterator方法返回的不是遍历器，因此报错。
+上面代码中，变量obj的Symbol.iterator方法返回的不是迭代器，因此报错。
 
 ### 调用默认iterator接口的场合
 
@@ -232,10 +232,10 @@ obj[Symbol.iterator] = () => 1;
 ```javascript
 
 let set = new Set().add('a').add('b').add('c');
-    
+
 let [x,y] = set;
 // x='a'; y='b'
-    
+
 let [first, ...rest] = set;
 // first='a'; rest=['b','c'];
 
@@ -279,14 +279,14 @@ let arr = [...iterable];
 
 ### 原生具备iterator接口的数据结构
 
-《数组的扩展》一章中提到，ES6对数组提供entries()、keys()和values()三个方法，就是返回三个遍历器。
+《数组的扩展》一章中提到，ES6对数组提供entries()、keys()和values()三个方法，就是返回三个迭代器。
 
 ```javascript
 
 var arr = [1, 5, 7];
 var arrEntries = arr.entries();
 
-arrEntries.toString() 
+arrEntries.toString()
 // "[object Array Iterator]"
 
 arrEntries === arrEntries[Symbol.iterator]()
@@ -294,14 +294,14 @@ arrEntries === arrEntries[Symbol.iterator]()
 
 ```
 
-上面代码中，entries方法返回的是一个遍历器（iterator），本质上就是调用了`Symbol.iterator`方法。
+上面代码中，entries方法返回的是一个迭代器（iterator），本质上就是调用了`Symbol.iterator`方法。
 
 字符串是一个类似数组的对象，也原生具有Iterator接口。
 
 ```javascript
 
 var someString = "hi";
-typeof someString[Symbol.iterator] 
+typeof someString[Symbol.iterator]
 // "function"
 
 var iterator = someString[Symbol.iterator]();
@@ -312,9 +312,9 @@ iterator.next()  // { value: undefined, done: true }
 
 ```
 
-上面代码中，调用`Symbol.iterator`方法返回一个遍历器，在这个遍历器上可以调用next方法，实现对于字符串的遍历。
+上面代码中，调用`Symbol.iterator`方法返回一个迭代器，在这个迭代器上可以调用next方法，实现对于字符串的遍历。
 
-可以覆盖原生的`Symbol.iterator`方法，达到修改遍历器行为的目的。
+可以覆盖原生的`Symbol.iterator`方法，达到修改迭代器行为的目的。
 
 ```javascript
 
@@ -323,7 +323,7 @@ var str = new String("hi");
 [...str] // ["h", "i"]
 
 str[Symbol.iterator] = function() {
-  return { 
+  return {
     next: function() {
       if (this._first) {
         this._first = false;
@@ -336,7 +336,7 @@ str[Symbol.iterator] = function() {
   };
 };
 
-[...str] // ["bye"]  
+[...str] // ["bye"]
 str // "hi"
 
 ```
@@ -383,7 +383,7 @@ for...of循环可以使用的范围包括数组、Set和Map结构、某些类似
 
 ### 数组
 
-数组原生具备iterator接口，for...of循环本质上就是调用这个接口产生的遍历器，可以用下面的代码证明。
+数组原生具备iterator接口，for...of循环本质上就是调用这个接口产生的迭代器，可以用下面的代码证明。
 
 ```javascript
 
@@ -475,13 +475,13 @@ for (let pair of map) {
 
 ### 计算生成的数据结构
 
-ES6的数组、Set、Map都部署了以下三个方法，调用后都返回遍历器。
+ES6的数组、Set、Map都部署了以下三个方法，调用后都返回迭代器。
 
-- entries() 返回一个遍历器，用来遍历 [键名, 键值] 组成的数组。对于数组，键名就是索引值；对于Set，键名与键值相同。Map结构的iterator接口，默认就是调用entries方法。
-- keys() 返回一个遍历器，用来遍历所有的键名。
-- values() 返回一个遍历器，用来遍历所有的键值。
+- entries() 返回一个迭代器，用来遍历 [键名, 键值] 组成的数组。对于数组，键名就是索引值；对于Set，键名与键值相同。Map结构的iterator接口，默认就是调用entries方法。
+- keys() 返回一个迭代器，用来遍历所有的键名。
+- values() 返回一个迭代器，用来遍历所有的键值。
 
-这三个方法调用后生成的遍历器，所遍历的都是计算生成的数据结构。
+这三个方法调用后生成的迭代器，所遍历的都是计算生成的数据结构。
 
 ```javascript
 
@@ -546,12 +546,12 @@ for (let x of 'a\uD83D\uDC0A') {
 let arrayLike = { length: 2, 0: 'a', 1: 'b' };
 
 // 报错
-for (let x of arrayLike) { 
+for (let x of arrayLike) {
   console.log(x);
 }
 
 // 正确
-for (let x of Array.from(arrayLike)) { 
+for (let x of Array.from(arrayLike)) {
   console.log(x);
 }
 

--- a/docs/set-map.md
+++ b/docs/set-map.md
@@ -27,7 +27,7 @@ Set函数可以接受一个数组作为参数，用来初始化。
 
 var items = new Set([1,2,3,4,5,5,5,5]);
 
-items.size 
+items.size
 // 5
 
 ```
@@ -40,7 +40,7 @@ let set = new Set();
 
 set.add({})
 set.size // 1
-    
+
 set.add({})
 set.size // 2
 
@@ -66,7 +66,7 @@ Set数据结构有以下方法。
 
 ```javascript
 
-s.add(1).add(2).add(2); 
+s.add(1).add(2).add(2);
 // 注意2被加入了两次
 
 s.size // 2
@@ -129,7 +129,7 @@ function dedupe(array) {
 
 ### 遍历操作
 
-Set结构有一个values方法，返回一个遍历器。
+Set结构有一个values方法，返回一个迭代器。
 
 ```javascript
 
@@ -143,7 +143,7 @@ for ( let item of set.values() ){
 
 ```
 
-Set结构的默认遍历器就是它的values方法。
+Set结构的默认迭代器就是它的values方法。
 
 ```javascript
 
@@ -206,7 +206,7 @@ for ( let [key, value] of set.entries() ){
 ```javascript
 
 let set = new Set(['red', 'green', 'blue']);
-let arr = [...set]; 
+let arr = [...set];
 // ['red', 'green', 'blue']
 
 ```
@@ -216,7 +216,7 @@ let arr = [...set];
 ```javascript
 
 let arr = [3, 5, 2, 2, 5, 5];
-let unique = [...new Set(arr)]; 
+let unique = [...new Set(arr)];
 // [3, 5, 2]
 
 ```
@@ -245,7 +245,7 @@ let b = new Set([4,3,2]);
 let union = new Set([...a, ...b]);
 // [1,2,3,4]
 
-let intersect = new Set([...a].filter(x => b.has(x))); 
+let intersect = new Set([...a].filter(x => b.has(x)));
 // [2,3]
 
 ```
@@ -306,7 +306,7 @@ ws.add(obj);
 ws.has(window); // true
 ws.has(foo);    // false
 
-ws.delete(window); 
+ws.delete(window);
 ws.has(window);    // false
 
 ws.clear();
@@ -387,7 +387,7 @@ map.get("title") // "Author"
 
 var map = new Map();
 
-map.set(['a'], 555); 
+map.set(['a'], 555);
 map.get(['a']) // undefined
 
 ```
@@ -420,7 +420,7 @@ map.get(k2) // 222
 ```javascript
 
 let map = new Map();
-    
+
 map.set(NaN, 123);
 map.get(NaN) // 123
 
@@ -464,7 +464,7 @@ let map = new Map()
 
 ```javascript
 
-var m = new Map(); 
+var m = new Map();
 
 m.set("edition", 6)        // 键是字符串
 m.set(262, "standard")     // 键是数值
@@ -494,20 +494,20 @@ m.get("edition")  // 6
 let map = new Map();
 map.set('foo', true);
 map.set('bar', false);
-    
+
 map.size // 2
 map.clear()
 map.size // 0
 
-```    
+```
 
 **（3）遍历**
 
-Map原生提供三个遍历器。
+Map原生提供三个迭代器。
 
-- keys()：返回键名的遍历器。
-- values()：返回键值的遍历器。
-- entries()：返回所有成员的遍历器。
+- keys()：返回键名的迭代器。
+- values()：返回键值的迭代器。
+- entries()：返回所有成员的迭代器。
 
 下面是使用实例。
 
@@ -548,7 +548,7 @@ for (let [key, value] of map) {
 
 ```
 
-上面代码最后的那个例子，表示Map结构的默认遍历器接口（Symbol.iterator属性），就是entries方法。
+上面代码最后的那个例子，表示Map结构的默认迭代器接口（Symbol.iterator属性），就是entries方法。
 
 ```javascript
 
@@ -589,12 +589,12 @@ let map0 = new Map()
   .set(1, 'a')
   .set(2, 'b')
   .set(3, 'c');
-    
+
 let map1 = new Map(
-  [...map0].filter(([k, v]) => k < 3) 
+  [...map0].filter(([k, v]) => k < 3)
 );
 // 产生Map结构 {1 => 'a', 2 => 'b'}
-    
+
 let map2 = new Map(
   [...map0].map(([k, v]) => [k * 2, '_' + v])
     );
@@ -634,7 +634,7 @@ map.forEach(function(value, key, map) {
 
 WeakMap结构与Map结构基本类似，唯一的区别是它只接受对象作为键名（null除外），不接受原始类型的值作为键名，而且键名所指向的对象，不计入垃圾回收机制。
 
-WeakMap的设计目的在于，键名是对象的弱引用（垃圾回收机制不将该引用考虑在内），所以其所对应的对象可能会被自动回收。当对象被回收后，WeakMap自动移除对应的键值对。典型应用是，一个对应DOM元素的WeakMap结构，当某个DOM元素被清除，其所对应的WeakMap记录就会自动被移除。基本上，WeakMap的专用场合就是，它的键所对应的对象，可能会在将来消失。WeakMap结构有助于防止内存泄漏。 
+WeakMap的设计目的在于，键名是对象的弱引用（垃圾回收机制不将该引用考虑在内），所以其所对应的对象可能会被自动回收。当对象被回收后，WeakMap自动移除对应的键值对。典型应用是，一个对应DOM元素的WeakMap结构，当某个DOM元素被清除，其所对应的WeakMap记录就会自动被移除。基本上，WeakMap的专用场合就是，它的键所对应的对象，可能会在将来消失。WeakMap结构有助于防止内存泄漏。
 
 下面是WeakMap结构的一个例子，可以看到用法上与Map几乎一样。
 


### PR DESCRIPTION
- 通常将 iterator 翻译为 `迭代器`。（Github diff 中文只能到语句级别，其实我只是修改 `遍历器` 为 `迭代器`。）
- 行尾空白是编辑器自动去掉的，建议不要保留 ：）
