### PR TITLE
Class 和 Module 一章的一些问题

### DIFF
--- a/docs/class.md
+++ b/docs/class.md
@@ -102,14 +102,14 @@ class Point {
 
 }
 
-var point = Point(2, 3);
+var point = new Point(2, 3);
 
 point.toString() // (2, 3)
 
 point.hasOwnProperty('x') // true
 point.hasOwnProperty('y') // true
 point.hasOwnProperty('toString') // false
-point.__proto__.hasOwnProperty('toString') // false 
+point.__proto__.hasOwnProperty('toString') // true 
 
 ```
 
@@ -263,7 +263,7 @@ class ColorPoint extends Point {
 
 class Point { /* ... */ }
 
-class ColorPoint extends Foo {
+class ColorPoint extends Point {
   constructor() {
   }
 }


### PR DESCRIPTION
`var point = new Point(2, 3);` 和 `class ColorPoint extends Point` 两个笔误。

`point.__proto__.hasOwnProperty('toString')` 中 `point.__proto__ === Point.prototype` 所以应该是 `true`。

另外本章还有些问题提在 https://github.com/ruanyf/es6tutorial/issues/43 和 https://github.com/ruanyf/es6tutorial/issues/46 里了。
