### PR TITLE
事件处理函数中的 this 并不是指向全局对象，而是指向绑定事件的节点元素

### DIFF
--- a/docs/function.md
+++ b/docs/function.md
@@ -571,7 +571,7 @@ var handler = {
 };
 ```
 
-上面代码的init方法中，使用了箭头函数，这导致this绑定handler对象，否则回调函数运行时，this.doSomething这一行会报错，因为此时this指向全局对象。
+上面代码的init方法中，使用了箭头函数，这导致this绑定handler对象，否则回调函数运行时，this.doSomething这一行会报错，因为此时this指向document对象。
 
 由于this在箭头函数中被绑定，所以不能用call()、apply()、bind()这些方法去改变this的指向。
 


### PR DESCRIPTION
``` js
document.addEventListener('click',function(){console.log(this === document)}); // true
```

从上面这段代码可以看出，事件处理函数里的 `this` 并不是指向 `window` 对象。如果你所说的“全局对象”并不是指 `window` 对象，我也觉得应该阐明这里的“全局对象”到底是指什么，以免产生歧义
