### PR TITLE
array和object两章勘误

### DIFF
--- a/docs/array.md
+++ b/docs/array.md
@@ -31,7 +31,7 @@ Array.from({ 0: "a", 1: "b", 2: "c", length: 3 });
 // [ "a", "b" , "c" ]
 ```
 
-对于还没有部署该方法的浏览器，可以用Array.prototyp.slice方法替代。
+对于还没有部署该方法的浏览器，可以用Array.prototype.slice方法替代。
 
 ```javascript
 const toArray = (() =>

--- a/docs/object.md
+++ b/docs/object.md
@@ -145,18 +145,6 @@ person.firstName.name // "get firstName"
 
 上面代码中，方法的name属性返回函数名（即方法名）。如果使用了取值函数，则会在方法名前加上get。如果是存值函数，方法名的前面会加上set。
 
-```javascript
-var doSomething = function() {
-  // ...
-};
-
-doSomething.bind().name
-// "bound doSomething"
-
-(new Function()).name
-// "anonymous"
-```
-
 有两种特殊情况：bind方法创造的函数，name属性返回“bound”加上原函数的名字；Function构造函数创造的函数，name属性返回“anonymous”。
 
 ```javascript


### PR DESCRIPTION
`Array.prototyp.slice`改为`Array.prototype.slice`
object.md中删除重复示例
