### PR TITLE
小错误更正 

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -8,7 +8,7 @@ ES6允许直接写入变量和函数，作为对象的属性和方法。这样�
 var foo = 'bar';
 var baz = {foo};
 // 等同于
-var baz = {foo: foo};
+var baz = {foo: 'bar'};
 
 function f(x, y) {
   return {x, y};


### PR DESCRIPTION
var foo = 'bar';
var baz = {foo};
// 等同于
var baz = {foo: 'bar'};

//而不是
var baz = {foo: foo};
