### PR TITLE
箭头函数只有一个参数时，可以更加简洁

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -260,12 +260,11 @@ const nodes = Array.from(foo);
 });
 
 // good
-[1, 2, 3].map(x => {
-  return x * x;
-});
+[1, 2, 3].map(x => x * x);
 
-// with more than one argument
+// with more argument and code
 [1, 2, 3].map((x,i) => {
+  console.log(x);
   return x * i;
 });
 ```

--- a/docs/style.md
+++ b/docs/style.md
@@ -260,8 +260,13 @@ const nodes = Array.from(foo);
 });
 
 // good
-[1, 2, 3].map((x) => {
+[1, 2, 3].map(x => {
   return x * x;
+});
+
+// with more than one argument
+[1, 2, 3].map((x,i) => {
+  return x * i;
 });
 ```
 

--- a/docs/style.md
+++ b/docs/style.md
@@ -260,11 +260,15 @@ const nodes = Array.from(foo);
 });
 
 // good
+[1, 2, 3].map((x) => {
+  return x * x;
+});
+
+// best
 [1, 2, 3].map(x => x * x);
 
-// with more argument and code
+// best
 [1, 2, 3].map((x,i) => {
-  console.log(x);
   return x * i;
 });
 ```

--- a/docs/style.md
+++ b/docs/style.md
@@ -266,11 +266,6 @@ const nodes = Array.from(foo);
 
 // best
 [1, 2, 3].map(x => x * x);
-
-// best
-[1, 2, 3].map((x,i) => {
-  return x * i;
-});
 ```
 
 箭头函数取代`Function.prototype.bind`，不应再用self/\_this/that绑定 this。


### PR DESCRIPTION
``` javascript
[1, 2, 3].map((x) => {
  return x * x;
}
```

可以简化成

``` javascript
[1, 2, 3].map(x => x * x)
```

当有多于一个参数时才需要加上括号()

``` javascript
[1, 2, 3].map((x,i) =>  x * i);
```

当函数体有更多代码时需要加上{}

``` javascript
[1, 2, 3].map((x,i) => {
  console.log(x);
  return x * i;
 });
```
