### PR TITLE
修改扩展运算符应用5的写法错误

### DIFF
--- a/docs/function.md
+++ b/docs/function.md
@@ -594,9 +594,9 @@ str.split('').reverse().join('')
 
 上面代码中，如果不用扩展运算符，字符串的`reverse`操作就不正确。
 
-**（5）类似数组的对象**
+**（5）实现了Iterator接口的对象**
 
-任何类似数组的对象，都可以用扩展运算符转为真正的数组。
+任何Iterator接口的对象，都可以用扩展运算符转为真正的数组。
 
 ```javascript
 var nodeList = document.querySelectorAll('div');


### PR DESCRIPTION
详情以及建议见 https://github.com/ruanyf/es6tutorial/issues/111。

5）类似数组的对象

任何类似数组的对象，都可以用扩展运算符转为真正的数组。

var nodeList = document.querySelectorAll('div');
var array = [...nodeList];
这里明显有问题，对于扩展运算符，只能对于可遍历（iterable）的对象

MDN
The spread operator allows an expression to be expanded in places where multiple arguments (for function calls) or multiple elements (for array literals) are expected.
