### PR TITLE
修正generator.md yield* 示例代码的一个误解

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -735,7 +735,7 @@ function* bar() {
 function* bar() {
   yield 'x';
   for (let v of foo()) {
-    console.log(v);
+    yield v;
   }
   yield 'y';
 }


### PR DESCRIPTION
previous code:

```
function* bar() {
  yield 'x';
  for (let v of foo()) {
    console.log(v);
  }
  yield 'y';
}
```

new code:

```
function* bar() {
  yield 'x';
  for (let v of foo()) {
    yield v;
  }
  yield 'y';
}
```
