### PR TITLE
删除错误的“()"

### DIFF
--- a/docs/decorator.md
+++ b/docs/decorator.md
@@ -381,7 +381,7 @@ export default function publish(topic, channel) {
 ```javascript
 import publish from "path/to/decorators/publish";
 
-class FooComponent () {
+class FooComponent {
   @publish("foo.some.message", "component")
   someMethod() {
     return {


### PR DESCRIPTION
class FooComponent() {} 里的()似乎是错误的，经测试无法运行，故予以删除。
