### PR TITLE
优化链接中出现双层锚点

### DIFF
--- a/js/ditto.js
+++ b/js/ditto.js
@@ -373,14 +373,13 @@ function router() {
         }
       }
     }
-
-    if (location.hash === '' || location.hash === menu[0]) {
+    if (location.hash === '' || '#' + getHash().nav === menu[0]) {
       $('#pageup').css('display', 'none');
     } else {
       $('#pageup').css('display', 'inline-block');
     }
 
-    if (location.hash === menu[(menu.length - 1)]) {
+    if ('#' + getHash().nav === menu[(menu.length - 1)]) {
       $('#pagedown').css('display', 'none');
     } else {
       $('#pagedown').css('display', 'inline-block');

--- a/js/ditto.js
+++ b/js/ditto.js
@@ -18,6 +18,30 @@ var ditto = {
     run: initialize
 };
 
+/**
+ * 获取当前hash
+ *
+ * @param {string} hash 要解析的hash，默认取当前页面的hash，如： nav#类目 => {nav:nav, anchor:类目}
+ * @description 分导航和页面锚点
+ * @return {Object} {nav:导航, anchor:页面锚点}
+ */
+var getHash = function (hash) {
+  hash = hash || window.location.hash.substr(1);
+
+  if (!hash) {
+    return {
+      nav: '',
+      anchor: ''
+    }
+  }
+
+  hash = hash.split('#');
+  return {
+    nav: hash[0],
+    anchor: decodeURIComponent(hash[1] || '')
+  }
+};
+
 var disqusCode = '<h3>留言</h3><div id="disqus_thread"></div>';
 var menu = new Array();
 
@@ -56,16 +80,18 @@ function init_sidebar_section() {
             menu.push(this.href.slice(this.href.indexOf('#')));
         });
         $('#pageup').on('click', function() {
+            var hash = getHash().nav;
             for (var i = 0; i < menu.length; i++) {
-                if (location.hash === '') break;
-                if (menu[i] === location.hash) break;
+                if (hash === '') break;
+                if (menu[i] === '#' + hash) break;
             }
             location.hash = menu[i - 1]
         });
         $('#pagedown').on('click', function() {
+            var hash = getHash().nav;
             for (var i = 0; i < menu.length; i++) {
-                if (location.hash === '') break;
-                if (menu[i] === location.hash) break;
+                if (hash === '') break;
+                if (menu[i] === '#' + hash) break;
             }
             location.hash = menu[i + 1];
         });
@@ -260,7 +286,7 @@ function show_loading() {
   return loading;
 }
 
-function router() {	
+function router() { 
   var path = location.hash.replace(/#([^#]*)(#.*)?/, './$1');
 
   var hashArr = location.hash.split('#');


### PR DESCRIPTION
双层锚点是指链接中有导航锚点和文章内部标题锚点，修复以下2个问题：
1. 当页面出现双层锚点时上一章、下一章链接出错/不正确，如：[#docs/intro#部署进度](http://es6.ruanyifeng.com/#docs/intro#部署进度)，此页面在点击下一章时出现错误，在点击上一章时不能跳转正确的上一章（前言）
2. 当打开第一章、最后一章并且有双锚点时，页面刷新后下一章按钮状态显示不正确（应该隐藏），同样上一章按钮也有同样问题，如：[#docs/reference#Symbol](http://es6.ruanyifeng.com/#docs/reference#Symbol)

ps: 这种场景多见于给他人分享整个url，其他打开后的页面
