### PR TITLE
统一 if 语句括号里的空格

### DIFF
--- a/docs/promise.md
+++ b/docs/promise.md
@@ -122,7 +122,7 @@ var getJSON = function(url) {
     client.send();
 
     function handler() {
-      if ( this.readyState !== 4 ) {
+      if (this.readyState !== 4) {
         return;
       }
       if (this.status === 200) {


### PR DESCRIPTION
handle() 函数里 有两个 if ，为什么里面的空格不同？
