### PR TITLE
问题修改

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -272,6 +272,31 @@ var reverseInt = n => n.toString().split('').reverse().join('') | 0;
 
 pipe(3).double.pow.reverseInt.get
 // 63
+
+var pipe = (function () {
+ return function (value) {
+		var funcStack = [];            // 认为和上面pipe同名不利于理解，换了一个名
+		var oproxy = new Proxy({} , {  // 使用了一个oproxy 存储Proxy的指向
+			get : function (pipeObject , fnName) {
+				if (fnName === "get") {
+					return funcStack.reduce(function (val , fn) {
+						return fn(val);
+					},value);
+				} 
+				funcStack.push(window[fnName]);
+				return oproxy;
+			}
+		});
+		
+		return oproxy;
+	}
+}());
+
+var double = n => n * 2;
+var pow    = n => n * n;
+var reverseInt = n => n.toString().split("").reverse().join("") | 0;
+
+pipe(3).double.pow.reverseInt.get; // 63
 ```
 
 上面代码设置Proxy以后，达到了将函数名链式使用的效果。


### PR DESCRIPTION
阮老师你好，在251行这个例子中，我在chrome (版本号Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36) 下 测试的时候出现了问题， 报了错误

 我研究完代码，发现在263行您return pipeObject ， pipeObject 指向应该是被代理的对象而不是，Proxy对象本身

当我做出如上修改后，代码即可正确运行，返回63

我也是初学者，我不知道是否是因为编译环境的原因导致如上问题的产生，但对于使用新chrome学习es6的同学可能会产生一些误导
也许是我理解有误，耽误您宝贵的时间，为此感到抱歉。
