### PR TITLE
Fix coding style in docs/string.md

### DIFF
--- a/docs/string.md
+++ b/docs/string.md
@@ -522,7 +522,7 @@ func('Jack') // "Hello Jack!"
 ```javascript
 var template = `
 <ul>
-  <% for(var i=0; i < data.supplies.length; i++) {%>
+  <% for(var i=0; i < data.supplies.length; i++) { %>
     <li><%= data.supplies[i] %></li>
   <% } %>
 </ul>


### PR DESCRIPTION
此处修改是针对`gitbook build`时会在此处报错：
`Template render error: (..\es6tutorial\docs\string.md) [Line 525, Column 50]
  tag name expected (In file 'docs/string.md')`
将`<% for(var i=0; i < data.supplies.length; i++) {%>`改为
`<% for(var i=0; i < data.supplies.length; i++) { %>`，在模版结束的`%>`前多一个空格就不会报错了。
