### PR TITLE
问题修改

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -466,6 +466,42 @@ var p = new Proxy(obj, {
 
 上面代码中，`obj`对象禁止扩展，结果使用`has`拦截就会报错。
 
+has 也可以用于拦截for...in操作
+
+```javascript
+let stu1 = {
+  name: "Owen",
+  score: 59
+}
+
+let stu2 = {
+  name: "Mark",
+  score: 99
+}
+
+let handler = {
+  has(target , prop) {
+    if(prop === "score" && target[prop] < 60) {
+    	console.log(`${target["name"]}偷偷地把考砸的分数藏起来了`);
+    	return false;
+    }
+
+    return prop in target; 
+  }
+}
+
+let oproxy1 = new Proxy(stu1 , handler);
+let oproxy2 = new Proxy(stu2 , handler);
+
+for(let a in oproxy1) {
+	console.log(oproxy1[a]);
+}
+
+for(let b in oproxy2) {
+	console.log(oproxy2[b]);
+}
+```
+
 ### construct()
 
 `construct`方法用于拦截`new`命令。


### PR DESCRIPTION
阮老师你好，我在阅读您Proxy书稿第553行，“注意与Proxy对象的`has`方法区分，后者用来拦截`in`操作符，对`for...in`循环无效。"  时，认为有所不妥

因为根据我在新chrome浏览器上的测试 ， 使用has 控制器是可以对for...in起作用的

我在介绍has 控制器的段落里添加了一个小例子来说明这个问题

可能我的理解并不到位出了差错，浪费了老师宝贵时间，望见谅
