### PR TITLE
fix bug to remove unnecessary preset

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -395,7 +395,7 @@ $ npm install --save-dev babelify babel-preset-es2015
 
 ```bash
 $  browserify script.js -o bundle.js \
-  -t [ babelify --presets [ es2015 react ] ]
+  -t [ babelify --presets [ es2015 ] ]
 ```
 
 上面代码将ES6脚本`script.js`，转为`bundle.js`，浏览器直接加载后者就可以了。


### PR DESCRIPTION
通过babelify转换ES6脚本时，需要依赖react似乎有些多余，同时也显得有些奇怪；而其下方package.json文件的相应配置中，并未出现react这一preset。
