### PR TITLE
remove unnecessary usage of Symbol.for

### DIFF
--- a/docs/symbol.md
+++ b/docs/symbol.md
@@ -246,7 +246,7 @@ Symbol作为属性名，该属性不会出现在`for...in`、`for...of`循环中
 ```javascript
 var obj = {};
 var a = Symbol('a');
-var b = Symbol.for('b');
+var b = Symbol('b');
 
 obj[a] = 'Hello';
 obj[b] = 'World';


### PR DESCRIPTION
在展示Object.getOwnPropertySymbols的用法时，使用Symbol.for并无必要；且此时尚未讲到Symbol.for，会对内容的理解造成些许困扰。
