### PR TITLE
Fix typo in async.md

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -98,7 +98,7 @@ Promise 的最大问题是代码冗余，原来的任务被Promise 包装了一�
 举例来说，读取文件的协程写法如下。
 
 ```javascript
-function *asnycJob() {
+function *asyncJob() {
   // ...其他代码
   var f = yield readFile(fileA);
   // ...其他代码


### PR DESCRIPTION
代码块里面的方法名和文本里面的方法名不一致
