### PR TITLE
edit (fix typo) in arraybuff.md

### DIFF
--- a/docs/arraybuffer.md
+++ b/docs/arraybuffer.md
@@ -629,9 +629,9 @@ let tarr = Uint8Array.of(1,2,3);
 
 // 方法三
 let tarr = new Uint8Array(3);
-tarr[0] = 0;
-tarr[1] = 1;
-tarr[2] = 2;
+tarr[0] = 1;
+tarr[1] = 2;
+tarr[2] = 3;
 ```
 
 ### TypedArray.from()


### PR DESCRIPTION
三种建立 TypedArray 的方法对比处，第三种方法初始数据应该是有个笔误，将 `[1, 2, 3]` 写成了 `[0, 1, 2]`。

话说我还发现这一节里有些数据类型/函数名描述的时候使用了 markdown 的行内代码语法（`TypedArray`），但是有些又没有（TypedArray），而且我也没看出来用不用的原则是什么，需不需要统一一下？
