### PR TITLE
240行代码块中缺少引号

### DIFF
--- a/docs/promise.md
+++ b/docs/promise.md
@@ -242,8 +242,7 @@ p.then((val) => console.log("fulfilled:", val))
   .catch((err) => console.log("rejected:", err));
 
 // 等同于
-
-p.then((val) => console.log(fulfilled:", val))
+p.then((val) => console.log("fulfilled:", val))
   .then(null, (err) => console.log("rejected:", err));
 ```
 


### PR DESCRIPTION
240行代码缺少引号。

``` javascript
p.then((val) => console.log(fulfilled:", val))
```

改为

``` javascript
p.then((val) => console.log("fulfilled:", val))
```
