### PR TITLE
修正一个“类的实例对象”节 的错误：“它们的原型都是Point”

### DIFF
--- a/docs/class.md
+++ b/docs/class.md
@@ -266,7 +266,7 @@ p1.__proto__ === p2.__proto__
 //true
 ```
 
-上面代码中，`p1`和`p2`都是Point的实例，它们的原型都是Point，所以`__proto__`属性是相等的。
+上面代码中，`p1`和`p2`都是Point的实例，它们的原型都是Point.prototype，所以`__proto__`属性是相等的。
 
 这也意味着，可以通过实例的`__proto__`属性为Class添加方法。
 


### PR DESCRIPTION
“类的实例对象 ”中举的例子 
var p1 = new Point(2,3);
var p2 = new Point(3,2);

p1.__proto__ === p2.__proto__
//true

上面代码中，p1和p2都是Point的实例，它们的原型都是Point，所以__proto__属性是相等的。