### PR TITLE
Update module.md

### DIFF
--- a/docs/module.md
+++ b/docs/module.md
@@ -21,7 +21,7 @@ ES6 模块不是对象，而是通过`export`命令显式指定输出的代码�
 
 ```javascript
 // ES6模块
-import { stat, exists, readFile } from 'fs';
+import { stat, exists, readFile } from 'fs';有问题
 ```
 
 上面代码的实质是从`fs`模块加载3个方法，其他方法不加载。这种加载称为“编译时加载”或者静态加载，即 ES6 可以在编译时就完成模块加载，效率要比 CommonJS 模块的加载方式高。当然，这也导致了没法引用 ES6 模块本身，因为它不是对象。


### PR DESCRIPTION
前面CommonJS规范那里用require导入fs文件，说明fs文件对外的接口是用Module.exports导出的，那这里又用import导入fs文件，是不是说明module.exports导出的既可以用require方法导入，也可以用import方法导入呢。
我再项目中也发现有人引入react.js直接用的是import React，{Component} from ‘react'，但是’react.js‘文件里的代码是
'use strict';

module.exports = require('./lib/React');
，所以这不是应该用require引入吗，为什么用import React, {Component} from 'react'呢？