### PR TITLE
fix restore generator.md

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -1145,14 +1145,14 @@ var clock = function() {
 上面代码的clock函数一共有两种状态（Tick和Tock），每运行一次，就改变一次状态。这个函数如果用Generator实现，就是下面这样。
 
 ```javascript
-var clock = function*() {
+var clock = (function*() {
   while (true) {
     console.log('Tick!');
     yield;
     console.log('Tock!');
     yield;
   }
-};
+})();
 ```
 
 上面的Generator实现与ES5实现对比，可以看到少了用来保存状态的外部变量`ticking`，这样就更简洁，更安全（状态不会被非法篡改）、更符合函数式编程的思想，在写法上也更优雅。Generator之所以可以不用外部变量保存状态，是因为它本身就包含了一个状态信息，即目前是否处于暂停态。


### PR DESCRIPTION
今日拜读阮老师的作品时偶遇一处小问题 请您过目

按照原文的实现
普通状态机
```JavaScript
var ticking = true;
var clock = function() {
  if (ticking)
    console.log('Tick!');
  else
    console.log('Tock!');
  ticking = !ticking;
}
// 其调用方式为clock()
```
Generator状态机
```JavaScript
var clock = function*() {
  while (true) {
    console.log('Tick!');
    yield;
    console.log('Tock!');
    yield;
  }
};
// 其调用方式本应为var bar = clock(); bar.next();
// 但是读者在这里十分容易受普通状态机的调用方式影响
// 误用了 clock() 或 clock.next() 这两种调用方式
```

我认为 造成这种错误的原因是: 普通状态机的实现clock为状态机, 而Generator状态机的实现给出了状态机的构造函数
所以 我建议将Generator状态机换为以下实现
```JavaScript
var clock = (function*() {
  while (true) {
    console.log('Tick!');
    yield;
    console.log('Tock!');
    yield;
  }
})();
// 其调用方式为 clock.next()
```
