### PR TITLE
9.对象的扩展 方法的name属性部分需修改

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -246,7 +246,7 @@ myObject // Object {[object Object]: "valueB"}
 ```javascript
 const person = {
   sayName() {
-    console.log(this.name);
+    console.log('hello!');
   },
 };
 


### PR DESCRIPTION
在 http://es6.ruanyifeng.com/#docs/object#方法的-name-属性 中，“console.log(this.name)” 不应该出现，这里的“this”指代的是方法所处的对象，即 person，该对象并不存在 name 属性，与本节所讲方法的属性毫无关系，易引起误导，应修改。