### PR TITLE
代码片段有误

### DIFF
--- a/docs/decorator.md
+++ b/docs/decorator.md
@@ -251,12 +251,12 @@ function foo() {
 上面的代码，意图是执行后`counter`等于1，但是实际上结果是`counter`等于0。因为函数提升，使得实际执行的代码是下面这样。
 
 ```javascript
-var counter;
-var add;
-
 @add
 function foo() {
 }
+
+var counter;
+var add;
 
 counter = 0;
 


### PR DESCRIPTION
http://es6.ruanyifeng.com/#docs/decorator#为什么修饰器不能用于函数？ 这一节的第二个代码片段，函数声明和变量声明都会提升，但是函数声明先于变量声明。