### PR TITLE
using Thunk function before defined

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -287,14 +287,14 @@ JavaScript语言是传值调用，它的Thunk函数含义有所不同。在JavaS
 fs.readFile(fileName, callback);
 
 // Thunk版本的readFile（单参数版本）
-var readFileThunk = Thunk(fileName);
-readFileThunk(callback);
-
 var Thunk = function (fileName){
   return function (callback){
     return fs.readFile(fileName, callback);
   };
 };
+
+var readFileThunk = Thunk(fileName);
+readFileThunk(callback);
 ```
 
 上面代码中，fs模块的readFile方法是一个多参数函数，两个参数分别为文件名和回调函数。经过转换器处理，它变成了一个单参数函数，只接受回调函数作为参数。这个单参数版本，就叫做Thunk函数。


### PR DESCRIPTION
这里的 Thunk 函数是使用函数表达式定义的，意味着 Thunk 函数不能在定义前使用。