### PR TITLE
class.md：ES6/Class特性中关于使用super关键字赋值时的一些修正

### DIFF
--- a/docs/class.md
+++ b/docs/class.md
@@ -889,6 +889,8 @@ let b = new B();
 
 上面代码中，`super.x`赋值为`3`，这时等同于对`this.x`赋值为`3`。而当读取`super.x`的时候，读的是`A.prototype.x`，所以返回`undefined`。
 
+(p.s 在通过babel来使用ES6的Class特性的情况下，上述代码中的this.x依然为2，没有被super.x修改为3，babel无法在子类中通过super来对父类中的prototype属性进行修改。babel所用版本为浏览器端babel-standalone@6.23.16.23.1，https://unpkg.com/babel-standalone@6.23.1)
+
 注意，使用`super`的时候，必须显式指定是作为函数、还是作为对象使用，否则会报错。
 
 ```javascript


### PR DESCRIPTION
阮老师，您好，在ES6/Class特性中，使用super关键字赋值时，会修改子类实例的属性的情况，经测试在babel的环境下，与书中所述不符，super.x并未修改this.x的值，不知道这是属于babel实现上的个例，还是ES6普遍的规定？我所使用的babel是浏览器端的babel-standalone@6.23.16.23.1，https://unpkg.com/babel-standalone@6.23.1。