### PR TITLE
修复类的静态属性中实例代码的错误

### DIFF
--- a/docs/class.md
+++ b/docs/class.md
@@ -1344,7 +1344,7 @@ class MyClass {
   static myStaticProp = 42;
 
   constructor() {
-    console.log(MyClass.myProp); // 42
+    console.log(MyClass.myStaticProp); // 42
   }
 }
 ```


### PR DESCRIPTION
class MyClass {
  static myStaticProp = 42;

  constructor() {
    console.log(MyClass.myProp); // 42
  }
}
修改为：
class MyClass {
  static myStaticProp = 42;

  constructor() {
    console.log(MyClass.myStaticProp); // 42
  }
}