### PR TITLE
fix typo: proxy instead of handler

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -68,7 +68,7 @@ proxy.a = 'b';
 target.a // "b"
 ```
 
-上面代码中，`handler`是一个空对象，没有任何拦截效果，访问`handler`就等同于访问`target`。
+上面代码中，`handler`是一个空对象，没有任何拦截效果，访问`proxy`就等同于访问`target`。
 
 一个技巧是将 Proxy 对象，设置到`object.proxy`属性，从而可以在`object`对象上调用。
 


### PR DESCRIPTION
when handler is empty, proxy (instead of handler) should be equal to target