### PR TITLE
The position of the asterisk is incorrect

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -585,7 +585,7 @@ try {
 Generator函数体外抛出的错误，可以在函数体内捕获；反过来，Generator函数体内抛出的错误，也可以被函数体外的`catch`捕获。
 
 ```javascript
-function *foo() {
+function* foo() {
   var x = yield 3;
   var y = x.toUpperCase();
   yield y;


### PR DESCRIPTION
Combined with the previous content: 
```
由于Generator函数仍然是普通函数，所以一般的写法是上面的第三种，即星号紧跟在`function`关键字后面。**本书也采用这种写法**。
```
so, the position of the asterisk is incorrect ...