### PR TITLE
修正querySelectorAll返回的NodeList集合不能使用forEach方法遍历的描述

### DIFF
--- a/docs/array.md
+++ b/docs/array.md
@@ -37,7 +37,7 @@ function foo() {
 }
 ```
 
-上面代码中，`querySelectorAll`方法返回的是一个类似数组的对象，只有将这个对象转为真正的数组，才能使用`forEach`方法。
+上面代码中，`querySelectorAll`方法返回的是一个类似数组的对象，可以将这个对象转为真正的数组，再使用`forEach`方法。
 
 只要是部署了Iterator接口的数据结构，`Array.from`都能将其转为数组。
 


### PR DESCRIPTION
修正querySelectorAll返回的NodeList集合不能使用forEach方法遍历的描述.
1.在chrome中querySelectorAll返回的NodeList集合可以使用forEach方法遍历
document.querySelectorAll('td').forEach(function (p) {
  console.log(p instanceof Object);
});
输出:
6 true
undefined