### PR TITLE
es7 > es7/es2016

### DIFF
--- a/docs/array.md
+++ b/docs/array.md
@@ -334,7 +334,7 @@ console.log(entries.next().value); // [2, 'c']
 
 ## 数组实例的includes()
 
-`Array.prototype.includes`方法返回一个布尔值，表示某个数组是否包含给定的值，与字符串的`includes`方法类似。该方法属于ES7，但Babel转码器已经支持。
+`Array.prototype.includes`方法返回一个布尔值，表示某个数组是否包含给定的值，与字符串的`includes`方法类似。该方法属于ES7/ES2016，但Babel转码器已经支持。
 
 ```javascript
 [1, 2, 3].includes(2);     // true


### PR DESCRIPTION
现在官方按年份来，ES6/ES2015 因为之前有广泛的群众基础，ES7 还是叫的少 e.g. http://kangax.github.io/compat-table/es6/