### PR TITLE
增加本地预览的插件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 npm-debug.log
+node_modules/
+package-lock.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,13 @@
+const gulp = require('gulp');
+const bs = require('browser-sync').create();
+const reload = bs.reload;
+
+gulp.task('default', () => {
+    bs.init({
+        notify: false,
+        port: 9000,
+        server: {
+            baseDir: './',
+        }
+    })
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "es6tutorial",
+  "version": "1.0.0",
+  "description": "《ECMAScript 6入门》是一本开源的 JavaScript 语言教程，全面介绍 ECMAScript 6 新增的语法特性",
+  "main": "config.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ruanyf/es6tutorial.git"
+  },
+  "keywords": [
+    "javascript",
+    "ES6"
+  ],
+  "author": "ruanyf",
+  "license": "Creative Commons Attribution-NonCommercial 4.0 International License",
+  "bugs": {
+    "url": "https://github.com/ruanyf/es6tutorial/issues"
+  },
+  "homepage": "http://es6.ruanyifeng.com/",
+  "devDependencies": {
+    "browser-sync": "^2.18.12",
+    "gulp": "^3.9.1"
+  }
+}


### PR DESCRIPTION
首先感谢阮老师的书!

经常浏览 <http://es6.ruanyifeng.com>，但是不知为何网站会时常加载不出来，所以特别想本地预览。

![image](https://user-images.githubusercontent.com/24730006/27464770-c86a6e1c-5801-11e7-9aad-c18e51f83cec.png)

本地直接网页形式预览的话，要么搭一个本地服务器，要么就用插件形式。我想了想，搭建本地服务器流程太多，不如直接用 browser-sync 的插件的好，所以就简单写了一个可以本地浏览的 gulpfile ，我想这样能帮助更多的伙伴学习。

这个虽然不是这本书的内容，但是我觉得还是有些必要，希望阮老师能合并。

预览方式：
1. 安装 Nodejs 以及全局 gulp-cli
2. 在项目目录下运行 npm install 安装依赖包
3. 在项目目录下运行 gulp 即可预览