### PR TITLE
源于继承原生构造函数的实例代码的小建议

### DIFF
--- a/docs/class-extends.md
+++ b/docs/class-extends.md
@@ -580,6 +580,7 @@ class VersionedArray extends Array {
   }
   revert() {
     this.splice(0, this.length, ...this.history[this.history.length - 1]);
+    this.history.pop();
   }
 }
 


### PR DESCRIPTION
实例代码中，VersionedArray实现的是带有版本的数组类，那么我认为在回滚到上一个状态必须要弹出this.history中的最后一项，否则无法连续回滚，所以增加了:
```javascript
this.history.pop()
```