### PR TITLE
修改Generator函数为习惯写法

### DIFF
--- a/docs/generator-async.md
+++ b/docs/generator-async.md
@@ -102,7 +102,7 @@ Promise 的最大问题是代码冗余，原来的任务被 Promise 包装了一
 举例来说，读取文件的协程写法如下。
 
 ```javascript
-function *asyncJob() {
+function* asyncJob() {
   // ...其他代码
   var f = yield readFile(fileA);
   // ...其他代码


### PR DESCRIPTION
在 “Generator 函数的语法”一章中，有如下介绍，所以我建议进行本次修改。
```js
function * foo(x, y) { ··· }
function *foo(x, y) { ··· }
function* foo(x, y) { ··· }
function*foo(x, y) { ··· }
```
**由于 Generator 函数仍然是普通函数，所以一般的写法是上面的第三种，即星号紧跟在function关键字后面。本书也采用这种写法**。