### PR TITLE
Update promise.md

### DIFF
--- a/docs/promise.md
+++ b/docs/promise.md
@@ -461,7 +461,7 @@ someAsyncThing().then(function() {
 }).catch(function(error) {
   console.log('oh no', error);
   // 下面一行会报错，因为 y 没有声明
-  y + 2;
+  y + 2;  (此错误会传递到外层)
 }).then(function() {
   console.log('carry on');
 });


### PR DESCRIPTION
someAsyncThing().then(function() {
  return someOtherAsyncThing();
}).catch(function(error) {
  console.log('oh no', error);
  // 下面一行会报错，因为 y 没有声明
  y + 2;  (此错误会传递到外层)
}).then(function() {
  console.log('carry on');
});
// oh no [ReferenceError: x is not defined]
上面代码中，`catch`方法抛出一个错误，因为后面没有别的`catch`方法了，导致这个错误不会被捕获，也不会传递到外层（应该会传递到外层）。如果改写一下，结果就不一样了。