### PR TITLE
docs: 改进表述

### DIFF
--- a/docs/arraybuffer.md
+++ b/docs/arraybuffer.md
@@ -62,7 +62,7 @@ const dataView = new DataView(buf);
 dataView.getUint8(0) // 0
 ```
 
-上面代码对一段32字节的内存，建立`DataView`视图，然后以不带符号的8位整数格式，读取第一个元素，结果得到0，因为原始内存的`ArrayBuffer`对象，默认所有位都是0。
+上面代码对一段32字节的内存，建立`DataView`视图，然后以不带符号的8位整数格式，从偏移0开始读取8bit数据，结果得到0，因为原始内存的`ArrayBuffer`对象，默认所有位都是0。
 
 另一种TypedArray视图，与`DataView`视图的一个区别是，它不是一个构造函数，而是一组构造函数，代表不同的数据格式。
 


### PR DESCRIPTION
“第一个元素”含义不明确容易让人混淆。arraybuffer本身是底层内存空间，（第n个）元素是从读取数据的角度来说的。用于读取出信息赋值给的变量而已。而此处读取操作仅执行了一次，没有多次读取，不存在多个元素需要表述的情况。所以不应该使用序列表述，否则读者会疑问那第二个元素在哪儿？ 再者此处是针对 arraybuffer 的案例，应该从arraybuffer的角度来叙述，采用其相关用语。比如bit, byte, 第n个字节等等更好。