### PR TITLE
docs: 变量名改为习惯用法

### DIFF
--- a/docs/module.md
+++ b/docs/module.md
@@ -404,9 +404,9 @@ export {add as default};
 // export default add;
 
 // app.js
-import { default as xxx } from 'modules';
+import { default as foo } from 'modules';
 // 等同于
-// import xxx from 'modules';
+// import foo from 'modules';
 ```
 
 正是因为`export default`命令其实只是输出一个叫做`default`的变量，所以它后面不能跟变量声明语句。

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -181,7 +181,7 @@ let proto = new Proxy({}, {
 });
 
 let obj = Object.create(proto);
-obj.xxx // "GET xxx"
+obj.foo // "GET foo"
 ```
 
 上面代码中，拦截操作定义在`Prototype`对象上面，所以如果读取`obj`对象继承的属性时，拦截会生效。


### PR DESCRIPTION
xxx这种名称偏向于口语化，适用于不严格的使用环境。 开发常用的约定俗称的随机名是 foo, bar, baz 等等