### PR TITLE
Minor changes

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -202,7 +202,7 @@ async function getTitle(url) {
   let html = await response.text();
   return html.match(/<title>([\s\S]+)<\/title>/i)[1];
 }
-getTitle('https://tc39.github.io/ecma262/').then(console.log)
+getTitle('https://tc39.github.io/ecma262/').then(v => console.log(v))
 // "ECMAScript 2017 Language Specification"
 ```
 


### PR DESCRIPTION
将 `getTitle('https://tc39.github.io/ecma262/').then(console.log)`
改为`getTitle('https://tc39.github.io/ecma262/').then(v => console.log(v))`
与前面例子风格一致，同时便于理解。