### PR TITLE
divs返回一个类数组对象

### DIFF
--- a/docs/set-map.md
+++ b/docs/set-map.md
@@ -35,7 +35,7 @@ items.size // 5
 
 // 例三
 function divs () {
-  return [...document.querySelectorAll('div')];
+  return document.querySelectorAll('div');
 }
 
 const set = new Set(divs());


### PR DESCRIPTION
第49行“例三是接受类似数组的对象作为参数。”
因为divs()返回的已经是一个数组，故修改divs方法