### PR TITLE
[fix]: delete '//' in "proxy.md"

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -265,7 +265,7 @@ const dom = new Proxy({}, {
 
 const el = dom.div({},
   'Hello, my name is ',
-  dom.a({href: '//example.com'}, 'Mark'),
+  dom.a({href: '/example.com'}, 'Mark'),
   '. I like:',
   dom.ul({},
     dom.li({}, 'The web'),


### PR DESCRIPTION
阮老师好，line 268 的例子中，引号中的双斜线在代码块高亮中显示时好像变成注释了？

![image](https://user-images.githubusercontent.com/17965578/33774568-a7372c2c-dc76-11e7-90e6-803feddd997b.png)
