### PR TITLE
docs:Fix typo

### DIFF
--- a/docs/iterator.md
+++ b/docs/iterator.md
@@ -69,9 +69,9 @@ function makeIterator(array) {
 ```javascript
 var it = idMaker();
 
-it.next().value // '0'
-it.next().value // '1'
-it.next().value // '2'
+it.next().value // 0
+it.next().value // 1
+it.next().value // 2
 // ...
 
 function idMaker() {


### PR DESCRIPTION
The type of `value` is number, not string.