### PR TITLE
483行数组举例，返回数组长度为３，修改前逗号４个，数组长度为４

### DIFF
--- a/docs/array.md
+++ b/docs/array.md
@@ -480,7 +480,7 @@ Array.of(3).length // 1
 
 ```javascript
 Array() // []
-Array(3) // [, , ,]
+Array(3) // [ , , ]
 Array(3, 11, 8) // [3, 11, 8]
 ```
 


### PR DESCRIPTION
483行数组举例，返回数组长度为３，逗原文件号多了一个