### PR TITLE
Update module.md

### DIFF
--- a/docs/module.md
+++ b/docs/module.md
@@ -464,7 +464,7 @@ import _ from 'lodash';
 如果想在一条`import`语句中，同时输入默认方法和其他接口，可以写成下面这样。
 
 ```javascript
-import _, { each, each as forEach } from 'lodash';
+import _, { each, forEach } from 'lodash';
 ```
 
 对应上面代码的`export`语句如下。


### PR DESCRIPTION
这里有歧义。输出时已经each方法改写成forEach：'export { each as forEach }'，import时只需要引入forEach即可，不需要再import { each as forEach } from 'lodash'。如果你import的as表示的是export中的第二个export，那实际上第三个的export就不需要写了