### PR TITLE
fix: file name and link

### DIFF
--- a/docs/module-loader.md
+++ b/docs/module-loader.md
@@ -385,7 +385,7 @@ import * as baz from './a';
 // b.js
 module.exports = null;
 
-// es.js
+// es.mjs
 import foo from './b';
 // foo = null;
 
@@ -393,7 +393,7 @@ import * as bar from './b';
 // bar = { default:null };
 ```
 
-上面代码中，`es.js`采用第二种写法时，要通过`bar.default`这样的写法，才能拿到`module.exports`。
+上面代码中，`es.mjs`采用第二种写法时，要通过`bar.default`这样的写法，才能拿到`module.exports`。
 
 ```javascript
 // c.js
@@ -401,7 +401,7 @@ module.exports = function two() {
   return 2;
 };
 
-// es.js
+// es.mjs
 import foo from './c';
 foo(); // 2
 
@@ -466,7 +466,7 @@ console.log(es_namespace.default);
 下面是另一个例子。
 
 ```javascript
-// es.js
+// es.mjs
 export let foo = { bar:'my-default' };
 export { foo as bar };
 export function f() {};
@@ -673,7 +673,7 @@ export {foo};
 
 上面代码的第四行，改成了函数表达式，就不具有提升作用，执行就会报错。
 
-我们再来看 ES6 模块加载器[SystemJS](https://github.com/ModuleLoader/es6-module-loader/blob/master/docs/circular-references-bindings.md)给出的一个例子。
+我们再来看 ES6 模块加载器[SystemJS](https://github.com/ModuleLoader/es-module-loader/blob/v0.17.0/docs/circular-references-bindings.md#zebra-striping)给出的一个例子。
 
 ```javascript
 // even.js


### PR DESCRIPTION
1. "Node加载"小节统一`.mjs`文件名
2. `SystemJS`例子地址做了更换, 原来地址文章找不到

阮老师, 我还有个疑问, 在"ES6 模块的循环加载"小节中, 所举得这个例子
```javascript
$ babel-node
> import * as m from './even.js';
> m.even(10);
true
> m.counter
6
> m.even(20)
true
> m.counter
17
```
我本地无法运行会提示`Modules aren't supported in the REPL`, 在网络上查阅后得知
> https://babeljs.io/docs/en/next/babel-node.html 
> Due to technical limitations ES6-style module-loading is not fully supported in a babel-node REPL.

此处是否有错误, 还是我的配置问题?

