### PR TITLE
纠错

### DIFF
--- a/docs/generator-async.md
+++ b/docs/generator-async.md
@@ -487,7 +487,7 @@ function run(fn) {
   function next(err, data) {
     var result = gen.next(data);
     if (result.done) return;
-    result.value(next);
+     next(err, result.value)
   }
 
   next();


### PR DESCRIPTION
原来的写法会报  result.value is not a function