### PR TITLE
统一“抽象操作的运行流程”的描述

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -70,12 +70,12 @@ F.[[Call]](V, argumentsList)
 
 抽象操作的运行流程，一般是下面这样。
 
-> 1. Let `resultCompletionRecord` be `AbstractOp()`.
-> 1. If `resultCompletionRecord` is an abrupt completion, return `resultCompletionRecord`.
-> 1. Let `result` be `resultCompletionRecord.[[Value]]`.
+> 1. Let `result` be `AbstractOp()`.
+> 1. If `result` is an abrupt completion, return `result`.
+> 1. Set `result` to `result.[[Value]]`.
 > 1. return `result`.
 
-上面的第一步是调用抽象操作`AbstractOp()`，得到`resultCompletionRecord`，这是一个 Completion Record。第二步，如果这个 Record 属于 abrupt completion，就将`resultCompletionRecord`返回给用户。如果此处没有返回，就表示运行结果正常，所得的值存放在`resultCompletionRecord.[[Value]]`属性。第三步，将这个值记为`result`。第四步，将`result`返回给用户。
+上面的第一步调用了抽象操作`AbstractOp()`，得到`result`，这是一个 Completion Record。第二步，如果`result`属于 abrupt completion，就直接返回。如果此处没有返回，表示`result`属于 normal completion。第三步，将`result`的值设置为`resultCompletionRecord.[[Value]]`。第四步，返回`result`。
 
 ES6 规格将这个标准流程，使用简写的方式表达。
 


### PR DESCRIPTION
修改了两处：

1）步骤描述

`ReturnIfAbrupt(result)`  应该描述为：

> 1. If result is an abrupt completion, return result.
> 2. Set result to result.[[Value]]

而非

> 1. If resultCompletionRecord is an abrupt completion, return resultCompletionRecord.
> 2. Let result be resultCompletionRecord.[[Value]].

改写之后，方便简写前后的对照，而不至于对不上号。

另外，第一步也修改为：Let result be AbstractOp()

“Set result to result.[[Value]]”的写法参考了这里的：https://v8.dev/blog/understanding-ecmascript-part-1#completion-records

2) 简化了步骤之后的文字描述