### PR TITLE
fix(proposals): shell exec style

### DIFF
--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -596,7 +596,7 @@ console.log(1);
 $ node hello.js
 
 # hashbang 的方式
-$ hello.js
+$ ./hello.js
 ```
 
 对于 JavaScript 引擎来说，会把`#!`理解成注释，忽略掉这一行。


### PR DESCRIPTION
Executing file directly must start with (absolute/relative) path under Linux.
Linux 下直接执行脚本文件必须带上路径。比如执行当前目录下文件应该使用 `./foo` 的格式。