### PR TITLE
优化了 async 函数内部报错会导致 Promise 对象变为`reject`状态的例子

### DIFF
--- a/docs/async.md
+++ b/docs/async.md
@@ -184,10 +184,10 @@ async function f() {
 }
 
 f().then(
-  v => console.log(v),
-  e => console.log(e)
+  v => console.log(‘resolve’,v),
+  e => console.log('reject',e)
 )
-// Error: 出错了
+//reject Error: 出错了
 ```
 
 ### Promise 对象的状态变化


### PR DESCRIPTION
原来的例子并不能很明显的表示打印的内容来自于 reject 的回调。