### PR TITLE
字符串的扩展 展示例子有误

### DIFF
--- a/docs/string.md
+++ b/docs/string.md
@@ -505,10 +505,11 @@ function passthru(literals) {
   let i = 0;
 
   while (i < literals.length) {
-    result += literals[i++];
+    result += literals[i];
     if (i < arguments.length) {
       result += arguments[i];
     }
+    i++
   }
 
   return result;


### PR DESCRIPTION
function passthru(literals) {
  let result = '';
  let i = 0;

  while (i < literals.length) {
    result += literals[i];
    if (i < arguments.length) {
      result += arguments[i];
    }
    i++
  }

  return result;
}

i应该字拼接完才累加