### PR TITLE
勘误`super`的一个用法案例。

### DIFF
--- a/docs/class-extends.md
+++ b/docs/class-extends.md
@@ -370,7 +370,7 @@ class B extends A {
 let b = new B();
 ```
 
-上面代码中，`super.valueOf()`表明`super`是一个对象，因此就不会报错。同时，由于`super`使得`this`指向`B`的实例，所以`super.valueOf()`返回的是一个`B`的实例。
+上面代码中，`super.valueOf()`表明`super`是一个对象，因此就不会报错。此时，`super`指向父类的原型对象，`super.valueOf()`从此原型对象的原型链上而来。又因为`valueOf()`内部会从`this`获得值，所以`super.valueOf()`返回的是一个`B`的实例。
 
 最后，由于对象总是继承其他对象的，所以可以在任意一个对象中，使用`super`关键字。
 


### PR DESCRIPTION
详情请见修改