### PR TITLE
经过测试，继承的属性是可以被 Object.keys(obj) 遍历出来

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -364,7 +364,7 @@ ES6 一共有 5 种方法可以遍历对象的属性。
 
 **（2）Object.keys(obj)**
 
-`Object.keys`返回一个数组，包括对象自身的（不含继承的）所有可枚举属性（不含 Symbol 属性）的键名。
+`Object.keys`返回一个数组，包括对象自身的所有可枚举属性（不含 Symbol 属性）的键名。
 
 **（3）Object.getOwnPropertyNames(obj)**
 


### PR DESCRIPTION
麻烦 阮一峰老师有时间看下。

class P {
    constructor () {
        this.name = 'P';
        this.age = 10;
    }
}

class C extends P {
    constructor () {
        super()
    }
}

const C1 = new C();

Object.keys(C1) // name  age