### PR TITLE
便于Proxy时this问题的阅读理解

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1090,7 +1090,7 @@ target.m() // false
 proxy.m()  // true
 ```
 
-上面代码中，一旦`proxy`代理`target`，`target.m()`内部的`this`就是指向`proxy`，而不是`target`。
+上面代码中，一旦`proxy`代理`target`，`proxy.m()`内部的`this`就是指向`proxy`，而不是`target`。
 
 下面是一个例子，由于`this`指向的变化，导致 Proxy 无法代理目标对象。
 


### PR DESCRIPTION
target.m()内部的this就是指向proxy，如果改成 proxy.m()内部的this就是指向proxy，更容易阅读理解。