### PR TITLE
let.md在不允许重复声明章节中有一处勘误

### DIFF
--- a/docs/let.md
+++ b/docs/let.md
@@ -207,7 +207,7 @@ func() // 报错
 
 function func(arg) {
   {
-    let arg;
+    var arg;
   }
 }
 func() // 不报错


### PR DESCRIPTION
因此，不能在函数内部重新声明参数。

```javascript
function func(arg) {
  let arg;
}
func() // 报错

function func(arg) {
  {
    let arg;
  }
}
func() // 不报错
```
老师您看一下这两个代码段是一样的，按照我的理解下面的应该是var而不是let
应该是如下
```javascript
function func(arg) {
  let arg;
}
func() // 报错

function func(arg) {
  {
    var arg;
  }
}
func() // 不报错
```