### PR TITLE
docs(generator): update example

### DIFF
--- a/docs/generator.md
+++ b/docs/generator.md
@@ -552,26 +552,26 @@ g.throw(1);
 
 上面代码中，`g.throw(1)`执行时，`next`方法一次都没有执行过。这时，抛出的错误不会被内部捕获，而是直接在外部抛出，导致程序出错。这种行为其实很好理解，因为第一次执行`next`方法，等同于启动执行 Generator 函数的内部代码，否则 Generator 函数还没有开始执行，这时`throw`方法抛错只可能抛出在函数外部。
 
-`throw`方法被捕获以后，会附带执行下一条`yield`表达式。也就是说，会附带执行一次`next`方法。
+`throw`方法被内部捕获以后，会附带执行到下一条`yield`表达式，这种情况下等同于执行一次`next`方法。
 
 ```javascript
 var gen = function* gen(){
   try {
-    yield console.log('a');
+    yield 1;
   } catch (e) {
-    // ...
+    yield 2;
   }
-  yield console.log('b');
-  yield console.log('c');
+  yield 3;
 }
 
 var g = gen();
-g.next() // a
-g.throw() // b
-g.next() // c
+g.next() // { value:1, done:false }
+g.throw() // { value:2, done:false }
+g.next() // { value:3, done:false }
+g.next() // { value:undefined, done:true }
 ```
 
-上面代码中，`g.throw`方法被捕获以后，自动执行了一次`next`方法，所以会打印`b`。另外，也可以看到，只要 Generator 函数内部部署了`try...catch`代码块，那么遍历器的`throw`方法抛出的错误，不影响下一次遍历。
+上面代码中，`g.throw`方法被内部捕获以后，等同于执行了一次`next`方法，所以返回`{ value:2, done:false }`。另外，也可以看到，只要 Generator 函数内部部署了`try...catch`代码块，那么遍历器的`throw`方法抛出的错误，不影响下一次遍历。
 
 另外，`throw`命令与`g.throw`方法是无关的，两者互不影响。
 


### PR DESCRIPTION
每次返回一个值是否更直观一些？

原例
```js
var gen = function* gen(){
  try {
    yield console.log('a');
  } catch (e) {
    // ...
  }
  yield console.log('b');
  yield console.log('c');
}

var g = gen();
g.next() // a
g.throw() // b
g.next() // c
```

更改为
```js
var gen = function* gen(){
  try {
    yield 1;
  } catch (e) {
    yield 2;
  }
  yield 3;
}

var g = gen();
g.next() // { value:1, done:false }
g.throw() // { value:2, done:false }
g.next() // { value:3, done:false }
g.next() // { value:undefined, done:true }
```