### PR TITLE
类内部访问不存在私有属性应该是报错

### DIFF
--- a/docs/class.md
+++ b/docs/class.md
@@ -853,7 +853,7 @@ class A {
   #foo = 0;
   m() {
     console.log(#foo in this); // true
-    console.log(#bar in this); // false
+    console.log(#bar in this); // 报错
   }
 }
 ```


### PR DESCRIPTION
class A {
  #foo = 0;
  m() {
    console.log(#foo in this); // true
    console.log(#bar in this); // false
  }
}
类A内部没有#bar这个私有属性，所以这里会报错